### PR TITLE
Add tests around starting the configured cli command

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -40,7 +40,7 @@ impl Engine {
                     .spawn()?;
                 Ok("🔥  All engines running!")
             }
-            _ => Ok("  Not in Developmnet...Skipping"),
+            _ => Ok("  Not in Development...Skipping"),
         }
     }
 }
@@ -66,11 +66,22 @@ impl Fairing for Engine {
 mod tests {
     use super::*;
 
-
     #[test]
     fn it_should_do_nothing_outside_of_development() {
         let engine = Engine::new(CliCommand::NPM);
         let status = engine.run_command(Environment::Production);
-        assert!(status.is_ok(), "🔥  All engines running!");
+
+        assert!(status.is_ok());
+        match status {
+            Ok(v) => assert_eq!(v, "  Not in Development...Skipping"),
+            _ => ()
+        };
+    }
+
+    #[test]
+    fn it_should_return_err_on_bad_configuration() {
+        let broken_engine = Engine{command: "not-npm", current_dir: "./app", arg: "start"};
+        let status = broken_engine.run_command(Environment::Development);
+        assert!(status.is_err());
     } 
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -31,17 +31,17 @@ impl Engine {
         }
     }
 
-    pub fn run_command(&self, environment: Environment) -> Result<(), io::Error> {
+    pub fn run_command(&self, environment: Environment) -> Result<&'static str, io::Error> {
         match environment {
             Environment::Development => {
                 Command::new(self.command)
                     .current_dir(self.current_dir)
                     .arg(self.arg)
                     .spawn()?;
+                Ok("🔥  All engines running!")
             }
-            _ => (),
-        };
-        Ok(())
+            _ => Ok("  Not in Developmnet...Skipping"),
+        }
     }
 }
 
@@ -56,8 +56,21 @@ impl Fairing for Engine {
     fn on_launch(&self, rocket: &Rocket) {
         info!("💨  Ignition sequence start...");
         match self.run_command(rocket.config().environment) {
-            Ok(_) => info!("🔥  All engines running!"),
+            Ok(v) => info!("{}", v),
             Err(e) => warn!("{}", e)
         };
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+
+    #[test]
+    fn it_should_do_nothing_outside_of_development() {
+        let engine = Engine::new(CliCommand::NPM);
+        let status = engine.run_command(Environment::Production);
+        assert!(status.is_ok(), "🔥  All engines running!");
+    } 
 }


### PR DESCRIPTION
Add testing to ensure that we are doing nothing when we're not in development mode and that we return an error on a bad configuration rather than panicking and crashing the program. 

Related to implementing these tests I refactored `run_command` to return a message that will be used to print out information to the user on stdout.