### PR TITLE
Add configuration parsing for custom start scripts

### DIFF
--- a/Rocket.toml
+++ b/Rocket.toml
@@ -1,0 +1,5 @@
+#This Rocket.toml file is used for unit testing the Engine reading from config
+
+[development]
+igniter_app_dir = "test_app_dir_config"
+igniter_arg = "test_arg_config"


### PR DESCRIPTION
Closes #9 

We now will parse the Rocket.toml file in a project to for igniter specific configurations. All our configurations should start with `igniter` to differentiate them from the other things in that file. i.e. `igniter_arg = "local"` if you wanted to run a NPM script called local in your frontend project. Currently the idea is to only support two arguments specific to igniter in the Rocket.toml file, `igniter_arg` for the script to run and `igniter_app_dir` if the frontend application doesn't live in `/app`.

I also added `run` by default to be argument list as it is required by NPM and optional for Yarn. This just makes life easier when supporting both CLIs. There may be a better way to abstract this out in the future.