### PR TITLE
Add doc comments to document public api

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,14 +1,20 @@
+//! Igniter Engine that configures and runs the client CLI.
+
 use rocket::config::{Config, Environment};
 use rocket::fairing::{Fairing, Info, Kind};
 use rocket::Rocket;
 use std::io;
 use std::process::Command;
 
+///Supported CLI commands to pass to a new Engine.
 pub enum CliCommand {
+    ///Variant for running the NPM cli.
     NPM,
+    ///Variant for running the Yarn cli.
     YARN,
 }
 
+///Engine that represents the configured CLI and arguments to run.
 pub struct Engine {
     command: &'static str,
     current_dir: &'static str,
@@ -16,6 +22,7 @@ pub struct Engine {
 }
 
 impl Engine {
+    ///Create a new Engine taking in a CLI argument for which client CLI to run.
     pub fn new(command: CliCommand) -> Engine {
         match command {
             CliCommand::NPM => Engine {
@@ -45,6 +52,7 @@ impl Engine {
         }
     }
 
+    ///Run the configured CLI and parse configuration from rocket::config::Config.
     pub fn run_command(&self, config: &Config) -> Result<&'static str, io::Error> {
         match config.environment {
             Environment::Development => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
+//! Igniter is a Rocket.rs fairing for a better frontend development experience
+
 #![feature(plugin, decl_macro)]
+#![deny(missing_docs)]
 
 extern crate rocket;
 #[macro_use]


### PR DESCRIPTION
Closes #11

Added some documentation comments to the public code to document our public API. Also included 
`#![deny(missing_docs)]` so that any new public modules or functions have to be added to the documents. May want to add more detail to these later but I think this basic documentation is a good start.